### PR TITLE
(VMWARE-131) Adds roles to vro-plugin-user to allow orchestrator and task access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ matrix:
       env: CHECK=release_checks
     -
       env: CHECK=spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
-      rvm: 2.1.9
 branches:
   only:
     - master

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,9 +28,25 @@ class vra_puppet_plugin_prep (
 
   $vro_role_name = 'VRO Plugin User'
   $permissions   = [
-    { 'action'      => 'view_data',
+    { 'object_type' => 'cert_requests',
+      'action'      => 'accept_reject',
       'instance'    => '*',
-      'object_type' => 'nodes',
+    },
+    { 'object_type' => 'tasks',
+      'action'      => 'run',
+      'instance'    => '*',
+    },
+    { 'object_type' => 'nodes',
+      'action'      => 'view_data',
+      'instance'    => '*',
+    },
+    { 'object_type' => 'orchestrator',
+      'action'      => 'view',
+      'instance'    => '*',
+    },
+    { 'object_type' => 'puppet_agent',
+      'action'      => 'run',
+      'instance'    => '*',
     },
   ]
 

--- a/templates/vro_sudoer_file.epp
+++ b/templates/vro_sudoer_file.epp
@@ -19,5 +19,8 @@ Defaults:<%= $vro_plugin_user %> !requiretty
 <%= $vro_plugin_user %> ALL = (root) NOPASSWD: !/opt/puppetlabs/bin/puppet node purge pe-internal-peadmin-mcollective-client
 <%= $vro_plugin_user %> ALL = (root) NOPASSWD: /bin/ls -1 /etc/puppetlabs/code/environments/
 <%= $vro_plugin_user %> ALL = (root) NOPASSWD: /opt/puppetlabs/bin/puppet strings *
+<%= $vro_plugin_user %> ALL = (root) NOPASSWD: /usr/bin/cat /etc/puppetlabs/client-tools/services.conf
+<%= $vro_plugin_user %> ALL = (root) NOPASSWD: /usr/bin/curl *
+<%= $vro_plugin_user %> ALL = (root) NOPASSWD: /opt/puppetlabs/bin/puppet-job run *
 # FIXME: disallow -exec flag to find ... or stop using find in the plugin
 <%= $vro_plugin_user %> ALL = (root) NOPASSWD: /bin/find /etc/puppetlabs/code/environments/*


### PR DESCRIPTION
Updates to the vRO Puppet Plugin v3.2 include a workflow that runs puppet agent from the PE Orchestrator. In order to do this, the vro-plugin-user account needs more rbac permissions that previously defined.