### PR TITLE
Do not try to upgrade gems every puppet run

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,12 +95,12 @@ class vra_puppet_plugin_prep (
   }
 
   package { 'rgen':
-    ensure   => latest,
+    ensure   => present,
     provider => puppet_gem,
   }
 
   package { 'puppet-strings':
-    ensure   => latest,
+    ensure   => present,
     provider => puppet_gem,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,11 @@
 {
   "name": "jesse-vra_puppet_plugin_prep",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": "Jesse Reynolds",
   "summary": "Prepares a Puppet Enterprise master for vRA Puppet Plugin integration",
   "license": "Apache-2.0",
   "source": "https://github.com/jessereynolds/puppet-vra_puppet_plugin_prep",
+  "project_page": "https://github.com/jessereynolds/puppet-vra_puppet_plugin_prep",
   "issues_url": "https://github.com/jessereynolds/puppet-vra_puppet_plugin_prep/issues",
   "dependencies": [
     {


### PR DESCRIPTION
Changing 'latest' to 'present' in the gem package resources so we don't try and upgrade the gems every puppet run. 

Many customer environments do not allow the puppet agent on the master to connect to rubygems.org so gem installation is either done manually or by a one-off puppet run with proxy environment variables set. In such environments having gem versions set to 'latest' causes puppet run failures. 