### PR TITLE
optionally manage sshd_config

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,6 +4,7 @@ vra_puppet_plugin_prep::vro_password:      'puppetlabs'
 vra_puppet_plugin_prep::vro_password_hash: '$1$Fq9vkV1h$4oMRtIjjjAhi6XQVSH6.Y.'
 vra_puppet_plugin_prep::manage_autosign:    true
 vra_puppet_plugin_prep::manage_localuser:   true
+vra_puppet_plugin_prep::manage_sshd:        true
 vra_puppet_plugin_prep::autosign_secret:    'S3cr3tP@ssw0rd!'
 vra_puppet_plugin_prep::vro_email:          'vro-plugin-user@example'
 vra_puppet_plugin_prep::vro_display_name:   'vRO Puppet Plugin'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class vra_puppet_plugin_prep (
   String  $vro_password_hash,
   Boolean $manage_autosign,
   Boolean $manage_localuser,
+  Boolean $manage_sshd,
   String  $autosign_secret,
   String  $vro_email,
   String  $vro_display_name,
@@ -84,14 +85,16 @@ class vra_puppet_plugin_prep (
     content => epp('vra_puppet_plugin_prep/vro_sudoer_file.epp', { 'vro_plugin_user' => $vro_plugin_user }),
   }
 
-  sshd_config { 'PasswordAuthentication':
-    ensure => present,
-    value  => 'yes',
-  }
+  if $manage_sshd {
+    sshd_config { 'PasswordAuthentication':
+      ensure => present,
+      value  => 'yes',
+    }
 
-  sshd_config { 'ChallengeResponseAuthentication':
-    ensure => present,
-    value  => 'no',
+    sshd_config { 'ChallengeResponseAuthentication':
+      ensure => present,
+      value  => 'no',
+    }
   }
 
   package { 'rgen':


### PR DESCRIPTION
If sshd_config is already being managed the user may want to disable enforcement of the sshd_config configuration contained in this module. This adds the parameter `manage_sshd` which is true by default for backwards compatibility. 